### PR TITLE
Add include directive to preseed files

### DIFF
--- a/bin/remix/copy-files
+++ b/bin/remix/copy-files
@@ -69,7 +69,26 @@ fi
 
 print-status Copy preseed files...
 if [[ -e "${PATH_REMIX}/preseeds" ]]; then
-    sudo find -L "${PATH_REMIX}/preseeds" -type f -exec install --mode=0444 -t "${PATH_EXTRACT}/iso/preseed/" {} +
+    while read -r -d '' path; do
+        tempfile=$(mktemp)
+        while read -r line; do
+            # Check if line is an include directive
+            if [[ "${line}" == "#!include "* ]]; then
+                include_file=$(cut -d' ' -f2 <<<"${line}")
+                if [[ -f "${PATH_REMIX}/preseeds/${include_file}" ]]; then
+                    cat "${PATH_REMIX}/preseeds/${include_file}" >> "${tempfile}"
+                else
+                    print-warning "Include file not found: ${include_file}"
+                fi
+                continue
+            fi
+
+            echo "${line}" >> "${tempfile}"
+        done < "${path}"
+
+        file_name=$(basename "${path}")
+        sudo install --mode=0444 "${tempfile}" "${PATH_EXTRACT}/iso/preseed/${file_name}"
+    done < <(find -L "${PATH_REMIX}/preseeds" -type f -print0 | sort -z || true)
     print-finish
 else
     print-finish Not found any preseed files, skip.

--- a/docs/remix.md
+++ b/docs/remix.md
@@ -45,6 +45,18 @@ The configuration files live in the `/remix` directory. This works similarly to 
     linux	/casper/vmlinuz  file=/cdrom/preseed/zephyr.seed maybe-ubiquity quiet splash ---
     ```
 
+    !!! tip
+
+        In preseed files, an include directive is supported, so you can split your preseed configuration into multiple files.
+
+        **Example**
+        ```
+        # zephyr.seed
+
+        #!include default.seed
+        d-i ubiquity/custom_title_text string Custom Title Text only in zephyr.seed
+        ```
+
 1.  (Optional) Customize GRUB menu of the remixed ISO.
 
     You can override the stock `grub.cfg` with your own at `/remix/grub.cfg`.


### PR DESCRIPTION
Now it is possible to use the `#!include other.preseed` directive in preseed files to include othe preseed files.
This way it is possible to split your preseed configuration into multiple files, e.g. a default one and others with host-specific configs.