### PR TITLE
customize/services/apache: add apache-conf settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,17 +240,18 @@ jobs:
 
       - name: Execute scripts (1st pass)
         run: |
+          # Run php first to install PHP-FPM required by Apache
+          ./bin/zephyrctl customize tester php
           ./bin/zephyrctl customize tester apache
           ./bin/zephyrctl customize tester mariadb
-          ./bin/zephyrctl customize tester php
           ./bin/zephyrctl customize tester phpmyadmin
         shell: bash
 
       - name: Execute scripts (2nd pass)
         run: |
+          ./bin/zephyrctl customize tester php
           ./bin/zephyrctl customize tester apache
           ./bin/zephyrctl customize tester mariadb
-          ./bin/zephyrctl customize tester php
           ./bin/zephyrctl customize tester phpmyadmin
         shell: bash
 

--- a/bin/customize/services/apache
+++ b/bin/customize/services/apache
@@ -34,6 +34,30 @@ _install-module() {
     print-finish
 }
 
+## Enable Apache configs
+##
+## @param   $1  Global/Local
+## @param   $2  Config file
+############################
+_enable-conf() {
+    local selector="${1:?Selector missing}"
+    local cfg_file="${2:?Config file missing}"
+    local config configs=()
+
+    # shellcheck disable=SC2310
+    if is-empty-section "${cfg_file}" apache-conf; then
+        return 0
+    fi
+
+    print-header Enable Apache configs "[${selector}]..."
+    # shellcheck disable=SC2310,SC2311
+    for config in $(cfg-read "${cfg_file}" apache-conf); do
+        configs+=("${config}")
+    done
+    sudo a2enconf "${configs[@]}"
+    print-finish
+}
+
 ## Copy Apache config file
 ##
 ## @param   $1  Global/Local
@@ -83,11 +107,13 @@ fi
 # shellcheck disable=SC2310,SC2311
 if file=$(cfg-get "${profile}" services/global.cfg); then
     _install-module global "${file}"
+    _enable-conf global "${file}"
     cfg-eval "${file}" apache
 fi
 # shellcheck disable=SC2310,SC2311
 if file=$(cfg-get "${profile}" services/local.cfg); then
     _install-module local "${file}"
+    _enable-conf local "${file}"
     cfg-eval "${file}" apache
 fi
 

--- a/bin/customize/services/php
+++ b/bin/customize/services/php
@@ -79,10 +79,9 @@ for php_version in "${versions[@]}"; do
         _config local "${dir}"
     fi
 
-    print-header Restart services...
+    print-header Restart PHP-FPM "${php_version}"...
     sudo systemctl enable "php${php_version}-fpm.service"
     sudo systemctl restart "php${php_version}-fpm.service"
-    sudo a2enconf "php${php_version}-fpm"
     print-finish
 done
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -329,6 +329,7 @@ The module is for installation and the configuration of the [Apache web server](
         - `def_virt_host_name`: name for default vhost (which will also be used for certificate and key filenames)
         - `def_virt_host_subject`: default virtual host certificate subject
     - `apache-module`: list of Apache modules to enable. Format: "module_name" (one per line).
+    - `apache-conf`: list of Apache configuration files to enable. Format: "conf_name" (one per line).
 
 ---
 

--- a/example/profiles/default/services/global.cfg
+++ b/example/profiles/default/services/global.cfg
@@ -28,6 +28,15 @@ rewrite
 setenvif
 ssl
 
+## Apache configurations
+##
+## Format:
+## conf_name
+########################
+[apache-conf]
+php8.2-fpm
+php8.4-fpm
+
 ## MariaDB
 ##########
 [mariadb]


### PR DESCRIPTION
Enabling php-fpm Apache config in `customize/services/php` module is removed.
Now, you can use the new `apache-conf` setting in `customize/services/apache` module to do that.