### PR TITLE
customize/certificates: add root_ca_key options to configure CA key algorithm 

### DIFF
--- a/bin/customize/system/certificates
+++ b/bin/customize/system/certificates
@@ -14,6 +14,7 @@ source "${PROJECT_ROOT}/bin/bootstrap.sh"
 check-not-root
 
 profile="${1:?Profile missing}"
+root_ca_key=RSA,rsa_keygen_bits:4096
 root_ca_name=
 root_ca_subject=
 mok_key_name=
@@ -92,10 +93,15 @@ key_created=
 cert_created=
 print-status Create ROOT CA private key...
 if sudo test ! -e "/etc/ssl/private/${root_ca_name}.key"; then
-    sudo openssl genpkey \
-        -algorithm rsa \
-        -pkeyopt rsa_keygen_bits:4096 \
-        -out "/etc/ssl/private/${root_ca_name}.key"
+    # Parse comma-separated config string
+    IFS=',' read -ra key_opts <<< "${root_ca_key}"
+    options=(-algorithm "${key_opts[0]}")
+    unset 'key_opts[0]'
+    for option in "${key_opts[@]}"; do
+        options+=(-pkeyopt "${option}")
+    done
+
+    sudo openssl genpkey "${options[@]}" -out "/etc/ssl/private/${root_ca_name}.key"
     key_created=1
     print-finish
 else

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -447,6 +447,7 @@ Certificates signed by this CA are used by the `services/apache` and the `servic
 - `system/firefox-policies.json`: Firefox policy file.
 - `system/global.cfg`:
     - `certificate`: certificates script settings. Format: INI-file format.
+        - `root_ca_key`: key configuration for the root CA in format "algorithm,option1,option2,...". If not specified, defaults to 4096 bit RSA.
         - `root_ca_name`: self-signed Root Certificate Authority (CA) name
         - `root_ca_subject`: root CA subject
         - `mok_key_name`: Machine Owner Key (MOK) name

--- a/example/profiles/default/system/global.cfg
+++ b/example/profiles/default/system/global.cfg
@@ -8,6 +8,9 @@
 # Certificates
 ##############
 [certificate]
+# (Optional) Root CA key configuration (algorithm,option1,option2...)
+# If not specified, defaults to 4096 bit RSA
+root_ca_key=EC,ec_paramgen_curve:P-384
 # Self-signed Root Certificate Authority (CA) name
 root_ca_name=Zephyr
 # Root CA subject


### PR DESCRIPTION
You can use different algorithms (like EC) and key sizes besides the default 4096-bit RSA.