### PR TITLE
zephyrctl/uninstall: remove project root not install dir

### DIFF
--- a/bin/zephyrctl
+++ b/bin/zephyrctl
@@ -239,7 +239,7 @@ _uninstall() {
     print-finish
 
     print-status Remove Zephyr files...
-    sudo rm -rf "${INSTALL_DIR}"
+    sudo rm -rf "${PROJECT_ROOT}"
     print-finish
 }
 


### PR DESCRIPTION
Project root is where Zephyr is installed in the current install workflow