### PR TITLE
zephyrctl/post-install: add task to set Window System

### DIFF
--- a/bin/install/post-install.d/random
+++ b/bin/install/post-install.d/random
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+##################
+## Zephyr       ##
+##              ##
+## Post-install ##
+## Random       ##
+##################
+
+# Strict mode
+set -eufo pipefail
+IFS=$'\n\t'
+
+source "${PROJECT_ROOT}/bin/bootstrap.sh"
+check-root
+
+profile="${1:?Profile missing}"
+window_system=wayland
+shift
+
+# Read config file, get options
+# shellcheck disable=SC2310,SC2311
+if file=$(cfg-get "${profile}" install/global.cfg); then
+    cfg-eval "${file}" random
+fi
+# shellcheck disable=SC2310,SC2311
+if file=$(cfg-get "${profile}" install/local.cfg); then
+    cfg-eval "${file}" random
+fi
+
+[[ -z "${window_system}" ]] && error-exit Missing window_system
+
+print-status Set Display Manager to "${window_system}..."
+cfg_file=/etc/gdm3/custom.conf
+if [[ -r "${cfg_file}" ]]; then
+    value=True
+    [[ "${window_system}" == x11 ]] && value=False
+    sed -i -r "/^#?WaylandEnable=/ c WaylandEnable=${value}" "${cfg_file}"
+    print-finish
+else
+    print-error "Configuration file ${cfg_file} not found, skip."
+fi
+
+exit 0

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -202,6 +202,22 @@ You can configure `initramfs` also.
 
 ---
 
+### random
+
+Assortment of random, non-categorized post-installation tasks.
+
+**Tasks**
+
+- select Windowing System to use (e.g. X11 or Wayland)
+
+**Configuration**
+
+- `install/global.cfg`:
+    - `random`: random script settings. Format: INI-file format.
+        - `window_system`: Window System for GNOME, default is `wayland`
+
+---
+
 ## Other modules
 
 Random, non-categorized modules.

--- a/example/profiles/default/install/global.cfg
+++ b/example/profiles/default/install/global.cfg
@@ -11,6 +11,14 @@
 # Directory for GPT partition table backups
 backup_dir=/root/backup/gpt
 
+## Assorted configs
+###################
+[random]
+# Window System for GNOME
+# Options: x11, wayland
+# Default: wayland
+window_system=x11
+
 ## LUKS automount
 #################
 [luks]


### PR DESCRIPTION
You can select the default Window Manager (X11 or Wayland)