### PR TITLE
Customize modules: minor fixes

### DIFF
--- a/bin/customize/packages/apt
+++ b/bin/customize/packages/apt
@@ -87,9 +87,9 @@ if file=$(cfg-get "${profile}" packages/local.cfg); then
 fi
 
 # Deduplicate list of repositories
-mapfile -t repos < <(printf "%s\n" "${repos[@]}" | sort -u || true)
+[[ -n "${repos[*]}" ]] && mapfile -t repos < <(printf "%s\n" "${repos[@]}" | sort -u || true)
 for apt_repo in "${repos[@]}"; do
-    print-status Add apt repo: "${apt_repo}..."
+    print-header Add APT repo: "${apt_repo}..."
     sudo add-apt-repository --yes --no-update "${apt_repo}"
     print-finish
 done

--- a/bin/customize/packages/pip
+++ b/bin/customize/packages/pip
@@ -20,7 +20,7 @@ _install() {
     local cfg_file="${2:?Config file missing}"
 
     print-header Install pip packages "[${selector}]..."
-    pip install --upgrade --upgrade-strategy eager --no-warn-script-location -r "${cfg_file}"
+    sudo python3 -m pip install --root-user-action ignore --upgrade --upgrade-strategy eager --no-warn-script-location -r "${cfg_file}"
     print-finish
 }
 
@@ -41,7 +41,7 @@ print-header Install pip...
 tmp_file=$(mktemp)
 curl --disable --progress-bar --location -o "${tmp_file}" --url https://bootstrap.pypa.io/get-pip.py
 sudo python3 "${tmp_file}" --root-user-action ignore --target "$(python3 -c 'import sys; print(sys.path[-1])' || true)"
-sudo python3 -m pip install --upgrade pip --root-user-action ignore
+sudo python3 -m pip install --root-user-action ignore --upgrade pip
 print-finish
 
 # shellcheck disable=SC2310,SC2311

--- a/bin/customize/packages/snap
+++ b/bin/customize/packages/snap
@@ -82,4 +82,8 @@ for line in $(snap list --all | awk '/disabled/{print $1, $3}'); do
 done
 print-finish
 
+print-status Purge cache...
+sudo find /var/lib/snapd/cache -type f -delete
+print-finish
+
 exit 0

--- a/bin/customize/services/php
+++ b/bin/customize/services/php
@@ -57,7 +57,7 @@ if file=$(cfg-get "${profile}" services/local.cfg); then
 fi
 [[ -z "${version}" ]] && error-exit Missing version
 
-print-status Add apt repo: ppa:ondrej/php...
+print-header Add apt repo: ppa:ondrej/php...
 sudo add-apt-repository --yes --no-update ppa:ondrej/php
 print-finish
 

--- a/bin/customize/system/netplan
+++ b/bin/customize/system/netplan
@@ -21,7 +21,8 @@ _config() {
 
     print-status Config Netplan "[${selector}]..."
     sudo mkdir -p /etc/netplan/
-    find -L "${cfg_dir}" -mindepth 1 -maxdepth 1 -type f -exec sudo install --mode=0644 {} /etc/netplan/ \;
+    sudo chmod -R go-rwx /etc/netplan/
+    find -L "${cfg_dir}" -mindepth 1 -maxdepth 1 -type f -exec sudo install --mode=0600 {} /etc/netplan/ \;
     print-finish
 }
 

--- a/bin/customize/tools/gpg
+++ b/bin/customize/tools/gpg
@@ -25,4 +25,8 @@ if file=$(cfg-get "${profile}" tools/gpg-agent.conf); then
     print-finish
 fi
 
+print-status Set permissions for ~/.gnupg...
+chmod -R go-rwx ~/.gnupg
+print-finish
+
 exit 0

--- a/bin/customize/tools/nano
+++ b/bin/customize/tools/nano
@@ -36,6 +36,9 @@ source "${PROJECT_ROOT}/bin/bootstrap.sh"
 check-not-root
 
 profile="${1:?Profile missing}"
+
+install-apt nano
+
 # shellcheck disable=SC2310,SC2311
 if dir=$(cfg-get "${profile}" tools/nano/global.d); then
     _config global "${dir}"

--- a/bin/customize/tools/pass-update
+++ b/bin/customize/tools/pass-update
@@ -32,8 +32,7 @@ install-apt git make
 
 print-header Install pass-update...
 tmp_dir=$(mktemp -d)
-git clone https://github.com/roddhjav/pass-update.git "${tmp_dir}"
-git -C "${tmp_dir}" checkout "${version}"
+git clone --depth 1 --branch "${version}" https://github.com/roddhjav/pass-update.git "${tmp_dir}"
 sudo make -C "${tmp_dir}" install
 print-finish
 

--- a/zephyr.cfg
+++ b/zephyr.cfg
@@ -11,7 +11,7 @@ ASSETS_DIR="${INSTALL_DIR}/assets"
 # Remixed iso image file name
 ISO_FILE_NAME=zephyr.iso
 # Remixed iso image label
-ISO_LABEL=zephyr
+ISO_LABEL=ZEPHYR
 # Disabled modules
 MODULE_BLACKLIST=
 # Enabled modules


### PR DESCRIPTION
- customize/apt: dedupe list of repos only if not empty
- customize/gpg: strict permissions on gnupg home (remove group, world permissions)
- customize/nano: install nano APT package as dependency
- customize/netplan: strict permissions on config files (remove group, world permissions)
- customize/pass-update: git clone a shallow repo, only one commit
- customize/php: use print-header for add-apt-repository
- customize/pip: use sudo to run pip
- customize/snap: purge snaps cache (downloaded snaps)
- zephyr.cfg: make default ISO_LABEL uppercase